### PR TITLE
change text to int64 for model verification

### DIFF
--- a/clip_tf/converter/convert.py
+++ b/clip_tf/converter/convert.py
@@ -237,7 +237,7 @@ def verify(model_name: str, keras_model: keras.Model, image_url: str, text_optio
     # tf2
     image = image.permute(0, 2, 3, 1).detach().numpy()
     text = text.unsqueeze(0)  # grml... keras doesnt like different cardinality in batch dim
-    text = text.detach().numpy()
+    text = text.detach().numpy().astype(np.int64)
     logits_per_image, logits_per_text = keras_model.predict((image, text))
     tf_probs = tf.nn.softmax(logits_per_image, axis=1)
     tf_probs = np.array(tf_probs)


### PR DESCRIPTION
If the text isnt converted to int64 before passing to the model this error is thrown:
```
    ValueError: Exception encountered when calling layer 'clip' (type CLIP).
    
    Python inputs incompatible with input_signature:
      inputs: (
        (<tf.Tensor 'IteratorGetNext:0' shape=(None, 224, 224, 3) dtype=float32>, <tf.Tensor 'IteratorGetNext:1' shape=(None, 4, 77) dtype=int32>))
      input_signature: (
        (TensorSpec(shape=(None, None, None, 3), dtype=tf.float32, name='image'), TensorSpec(shape=(None, None, None), dtype=tf.int64, name='text'))).
    
    Call arguments received by layer 'clip' (type CLIP):
      • input=('tf.Tensor(shape=(None, 224, 224, 3), dtype=float32)', 'tf.Tensor(shape=(None, 4, 77), dtype=int32)')
```

After the change everything works as expected.