### PR TITLE
torch>=1.13.1 support, fixed text encoder export

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Robert Biehl
+Copyright (c) 2023 Robert Biehl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clip_tf/converter/convert.py
+++ b/clip_tf/converter/convert.py
@@ -5,6 +5,7 @@ import sys
 import urllib
 import warnings
 from typing import List
+import logging
 
 import numpy as np
 import requests
@@ -18,6 +19,8 @@ import clip
 from PIL import Image
 
 from clip_tf.model import build_model
+
+LOGGER = logging.Logger(__name__)
 
 MODELS = {
     "RN50": "https://openaipublic.azureedge.net/clip/models/afeb0e10f9e5a86da6080e35cf09123aca3b358a0c3e3b6c78a7b63bc04b6762/RN50.pt",
@@ -259,7 +262,8 @@ def get_cache_path(model: str, cache_path: str, type: str = None) -> str:
     return cache_path.format(model=sanitized_model_name)
 
 
-def convert(model_name: str, output: str, image_output: str = None, text_output: str = None, all: bool = False, should_verify: bool = True):
+def convert(model_name: str, output: str, image_output: str = None, text_output: str = None, all: bool = False,
+            should_verify: bool = True):
     model_url = MODELS[model_name]
     state_dict = download_statedict(model_url)
     model = build_model(state_dict)
@@ -272,22 +276,27 @@ def convert(model_name: str, output: str, image_output: str = None, text_output:
     load_pytorch_weights(model, state_dict, verbose=False)
 
     if should_verify:
+        LOGGER.info("Verifying converted model...")
         verify(model_name, model, image_url, text_options, verbose=True)
 
     # create SavedModel
     output_filename = get_cache_path(model_name, output)
+    LOGGER.info(f"Saving model: {output_filename}")
     model.save(output_filename)
 
     # load and test model
     if should_verify:
-        model = tf.keras.models.load_model(output_filename)
-        model.summary()
-        verify(model_name, model, image_url, text_options, verbose=True)
+        LOGGER.info("Verifying saved model...")
+        saved_model = tf.keras.models.load_model(output_filename)
+        saved_model.summary()
+        verify(model_name, saved_model, image_url, text_options, verbose=True)
 
+    # Dedicated export of image or text encoder
     if image_output is not None or all:
         image_output_filename = get_cache_path(model_name, image_output) if image_output else get_cache_path(model_name,
                                                                                                              output,
                                                                                                              "image")
+        LOGGER.info(f"Saving image encoder model: {image_output_filename}")
         model.visual.save(image_output_filename)
 
     text_output = text_output or (output.format(model="text_{model}") if all else None)
@@ -295,4 +304,17 @@ def convert(model_name: str, output: str, image_output: str = None, text_output:
         text_output_filename = get_cache_path(model_name, text_output) if text_output else get_cache_path(model_name,
                                                                                                           output,
                                                                                                           "text")
-        model.transformer.save(text_output_filename)
+        LOGGER.info(f"Saving text encoder model: {text_output_filename}")
+        inputs = keras.Input(shape=(None,), name="text", dtype=tf.int32)
+
+        # we have to create a layer to capture all variables used inside of encode_text as well. TODO: more elegant solution
+        class TextEncoder(tf.keras.layers.Layer):
+            def __init__(self, model: tf.keras.models.Model):
+                super().__init__()
+                self.model = model
+            def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
+                return model.encode_text(inputs)
+
+        outputs = TextEncoder(model)(inputs)
+        text_encoder = keras.models.Model(inputs=inputs, outputs=outputs)
+        text_encoder.save(text_output_filename)

--- a/clip_tf/converter/convert.py
+++ b/clip_tf/converter/convert.py
@@ -237,7 +237,7 @@ def verify(model_name: str, keras_model: keras.Model, image_url: str, text_optio
     # tf2
     image = image.permute(0, 2, 3, 1).detach().numpy()
     text = text.unsqueeze(0)  # grml... keras doesnt like different cardinality in batch dim
-    text = text.detach().numpy()
+    text = text.detach().numpy().astype(np.int32)
     logits_per_image, logits_per_text = keras_model.predict((image, text))
     tf_probs = tf.nn.softmax(logits_per_image, axis=1)
     tf_probs = np.array(tf_probs)
@@ -267,7 +267,7 @@ def convert(model_name: str, output: str, image_output: str = None, text_output:
     # predict to build shapes (model.build doesnt work, as it only supports float inputs)
     model.predict((
         np.ones((1, model.image_resolution, model.image_resolution, 3), np.float32),
-        np.ones((1, 4, 77), np.int64)
+        np.ones((1, 4, 77), np.int32)
     ))
     load_pytorch_weights(model, state_dict, verbose=False)
 
@@ -295,4 +295,4 @@ def convert(model_name: str, output: str, image_output: str = None, text_output:
         text_output_filename = get_cache_path(model_name, text_output) if text_output else get_cache_path(model_name,
                                                                                                           output,
                                                                                                           "text")
-        model.visual.save(text_output_filename)
+        model.transformer.save(text_output_filename)

--- a/clip_tf/model/clip.py
+++ b/clip_tf/model/clip.py
@@ -125,10 +125,12 @@ class CLIP(keras.Model):
     def dtype(self):
         return self.visual.conv1.weight.dtype
 
-    def encode_image(self, image):
+    @tf.function(input_signature=[tf.TensorSpec(shape=(None, None, None, 3), dtype=tf.float32, name="image")])
+    def encode_image(self, image: tf.Tensor):
         return self.visual(image)
 
-    def encode_text(self, text):
+    @tf.function(input_signature=[tf.TensorSpec(shape=(None, None), dtype=tf.int32, name="text")])
+    def encode_text(self, text: tf.Tensor):
         x = tf.nn.embedding_lookup(self.token_embedding, text)
         x = x + self.positional_embedding
         x = self.transformer(x)

--- a/clip_tf/model/clip.py
+++ b/clip_tf/model/clip.py
@@ -69,7 +69,7 @@ class CLIP(keras.Model):
         self.logit_scale = tf.Variable(np.ones([]) * np.log(1 / 0.07), dtype=tf.float32, name="logit_scale")
 
     def initialize_parameters(self):
-        # TODO: convert to tf, for model initialization (not needed for pretrained weights
+        # TODO: convert to tf, for model initialization (not needed for pretrained weights)
         self.token_embedding.assign(tf.random.normal(self.token_embedding.shape, stddev=0.02))
         self.positional_embedding.assign(tf.random.normal(self.positional_embedding.shape, stddev=0.01))
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.8
   - cudatoolkit==11.0.221
   - cudnn
-  - pytorch=1.7.1 #clip
+  - torch==1.13.1 #clip
   - torchvision #clip
   - pip:
       - tensorflow-gpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tensorflow>=2.4.0
 ftfy
 
 #clip pytorch dependencies
-torch==1.7.1
+torch==1.13.1
 torchvision
 regex
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="clip_tf",
     py_modules=["clip_tf"],
     version="1.0",
-    description="",
+    description="Tensorflow 2 / Keras converter for OpenAI/Clip originally provided in PyTorch.",
     author="Robert Biehl",
     packages=find_packages(exclude=["tests*"]),
     install_requires=[


### PR DESCRIPTION
* Fixes torch version compatibility
  Similar to fix in #5, but moving to int32 for text encoding, instead of int64.
  Should be compatible to torch 1.7.1 but increasing requirements due to known vulnerability below torch==1.13.1

* text_output parameter should now work as expected (it was incorrectly exporting the visual model before)